### PR TITLE
The beginnings of a file system

### DIFF
--- a/kernel/arch/i686/boot/boot1.c
+++ b/kernel/arch/i686/boot/boot1.c
@@ -75,33 +75,40 @@ void hlinit(struct multiboot_info *mbi_phys)
     printf("Hello, world!\n");
 
     struct fs_instance *fs = tmpfs_driver.mount(NULL, 0, NULL);
-    fs->driver->create(fs->root, "foo", IT_DIR);
-    
-    struct dentry *foo = fs->driver->lookup(fs->root, "foo");
 
-    char buf[7];
-    strcpy(buf, "bar000");
-    for (int i = 0; i < 1000; i++) {
-        buf[3] = '0' + i / 100;
-        buf[4] = '0' + (i % 100) / 10;
-        buf[5] = '0' + (i % 10);
-        fs->driver->create(foo->ino, buf, IT_REG);
-        struct dentry *file = fs->driver->lookup(foo->ino, buf);
-        fs->driver->write(file->ino, 0, "Hello, ", 7);
-        fs->driver->write(file->ino, 7, buf, 7);
-    }
+    fs->driver->create(fs->root, "lorem.txt", IT_REG);
 
-    for (int i = 0; i < 1000; i++) {
-        buf[3] = '0' + i / 100;
-        buf[4] = '0' + (i % 100) / 10;
-        buf[5] = '0' + (i % 10);
-        if (i == 999)
-            printf("");
-        struct dentry *file = fs->driver->lookup(foo->ino, buf);
-        char new_buf[14];
-        fs->driver->read(file->ino, 0, new_buf, 14);
-        printf("%s : %s\n", buf, new_buf);
-    }
+    const char *lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing "
+            "elit. In fermentum ac magna at varius. Vestibulum tortor tellus, "
+            "cursus id massa sit amet, placerat ullamcorper risus. Nullam ac "
+            "neque vel nibh pellentesque dapibus. Donec ac eros id eros "
+            "faucibus tincidunt. Fusce faucibus dapibus tincidunt. Mauris "
+            "mollis libero id magna ultricies vestibulum. Donec cursus ante "
+            "urna, ac tristique metus aliquam mattis. Praesent ut tempus sem, "
+            "eget lobortis felis. Praesent sed nibh ipsum. Pellentesque vitae "
+            "ante sem. Ut lobortis ex purus, in varius nunc ultricies eget.";
+
+    struct dentry *de = fs->driver->lookup(fs->root, "lorem.txt");
+    de->ino->fs_on->driver->write(de->ino, 0, "0001", 4);
+    de->ino->fs_on->driver->write(de->ino, 3, "23", 2);
+    if (de->ino->fs_on->driver->write(de->ino, 6, "0001", 2) > 0)
+        printf("ERROR");
+    de->ino->fs_on->driver->write(de->ino, 5, lorem, 556);
+    de->ino->fs_on->driver->write(de->ino, 560, "0002", 4);
+    de->ino->fs_on->driver->write(de->ino, 564, lorem, 556);
+    de->ino->fs_on->driver->write(de->ino, 1119, "0003", 4);
+    de->ino->fs_on->driver->write(de->ino, 1123, lorem, 4);
+    de->ino->fs_on->driver->write(de->ino, 1678, "0004", 4);
+    de->ino->fs_on->driver->write(de->ino, 1683, lorem, 556);
+    de->ino->fs_on->driver->write(de->ino, 2234, lorem, 556);
+    de->ino->fs_on->driver->write(de->ino, 2789, lorem, 556);
+    de->ino->fs_on->driver->write(de->ino, 3344, lorem, 556);
+    de->ino->fs_on->driver->write(de->ino, 3899, "0005", 4);
+    de->ino->fs_on->driver->write(de->ino, 3903, lorem, 556);
+
+    char buf[4200];
+    de->ino->fs_on->driver->read(de->ino, 0, buf, 4200);
+    printf("%s\n", buf);
 
     halt_loop();
 }

--- a/kernel/arch/i686/boot/boot1.c
+++ b/kernel/arch/i686/boot/boot1.c
@@ -1,19 +1,63 @@
+#include <stddef.h>
 #include <stdint.h>
 
 #include <stdio.h>
+
+#include <vendor/grub/multiboot2.h>
 
 #include <drivers/tty.h>
 #include <drivers/ps2_kb.h>
 #include <x86/interrupts.h>
 #include <x86/mem.h>
 
+struct multiboot_info {
+    uint32_t total_size;
+    uint32_t _resv04;
+    struct multiboot_tag tags[0];
+};
+
 /* defined in boot0.s */
 extern void halt_loop(void);
 
-void hlinit(uint32_t mbinfo_phys)
+void hlinit(struct multiboot_info *mbi_phys)
 {
     mem_init();
     tty_init();
+
+    /*
+     * Parse multiboot information structure.
+     *
+     * For now, only the memory map/info is useful for us.
+     * TODO: Parse ACPI tables, reclaim ACPI memory, get framebuffer info
+     */
+    struct multiboot_tag *tag;
+
+    for (tag = mbi_phys->tags;
+        tag->type != MULTIBOOT_TAG_TYPE_END;
+        tag = (void *)tag + ((tag->size + 7) & ~7)) {
+
+        switch (tag->type) {
+        case MULTIBOOT_TAG_TYPE_BASIC_MEMINFO:
+            mem_set_bounds(
+                ((struct multiboot_tag_basic_meminfo *)tag)->mem_lower,
+                ((struct multiboot_tag_basic_meminfo *)tag)->mem_upper);
+            break;
+        
+        case MULTIBOOT_TAG_TYPE_MMAP:
+            for (struct multiboot_mmap_entry *mmap =
+                    ((struct multiboot_tag_mmap *)tag)->entries;
+                
+                (void *)mmap < (void *)tag + tag->size;
+
+                mmap = (void *)mmap +
+                    ((struct multiboot_tag_mmap *)tag)->entry_size) {
+                
+                if (mmap->type != MULTIBOOT_MEMORY_AVAILABLE)
+                    mem_set_used(mmap->addr, mmap->len);
+            }
+            break;
+        }   
+    }
 
     setup_interrupts();
 

--- a/kernel/arch/i686/drivers/tty.c
+++ b/kernel/arch/i686/drivers/tty.c
@@ -28,7 +28,7 @@ static void tty_scroll(int lines)
 
 void tty_init()
 {
-    vga_buffer = mem_map_page(0xf0000000, 0xb8000, DEFAULT_PAGE_FLAGS);
+    vga_buffer = mem_map_page(K_MEM_DEV_START, 0xb8000, DEFAULT_PAGE_FLAGS);
 }
 
 void tty_putchar(char ch)

--- a/kernel/arch/i686/include/x86/mem.h
+++ b/kernel/arch/i686/include/x86/mem.h
@@ -62,8 +62,18 @@ enum page_flags {
     PAGE_DIRECTORY_FLAGS = PG_PRES | PG_RW | PG_US,
 };
 
-void mem_set_bounds(uint32_t lower, uint32_t upper);
-void mem_set_used(uint32_t phys, uint32_t min_size);
+/*
+ * Tells the memory manager the basic memory regions. (x86 specific)
+ * `lower`: size of lower memory (<1MiB, starts at 0)
+ * `upper`: size of upper memory (>1MiB, starts at 1MiB)
+ * e.g. on a system with video memory starting at 0xa0000 GRUB does not use
+ * the memory map for this but sets the `basic_meminfo#lower` field to 0xa0000.
+ * 
+ * NEEDS to be called before any physical memory allocations happen.
+ */
+void mem_init_regions(uint32_t lower, uint32_t upper);
+
+void mem_set_used(uint64_t phys, uint64_t min_size);
 void mem_init(void);
 
 /*

--- a/kernel/arch/i686/include/x86/mem.h
+++ b/kernel/arch/i686/include/x86/mem.h
@@ -3,6 +3,41 @@
 
 #include <stdint.h>
 
+/*
+ * Memory map
+ *
+ * 0x00000000: NULL (invalid, never mapped)
+ * 
+ * 0x00100000: User binary loaded here, followed immediately by user heap.
+ * This is in the spirit of the original UNIX systems where the "heap" was just
+ * the "data segment" of the binary dynamically extended with `sbrk()`.
+ * 
+ * 0xbfffffff: User stack starts here and grows downwards.
+ * NOTE: The kernel allocates pages for the stack automatically on page fault.
+ * It needs to check if heap and stack are going to collide!
+ * 
+ * Max size of user memory (binary + heap + stack) = 3GiB
+ * 
+ * 0xc0000000: Start of physical memory. BIOS and bootloader memory.
+ * 0xc0100000: Kernel binary loaded here
+ * Max size of kernel binary = 256MiB (sufficient! Linux + initrd ~ 110MiB)
+ * 
+ * 0xd0000000-0xefffffff: Kernel heap
+ * Max size of kernel heap = 512MiB (sufficient?)
+ * 
+ * 0xf0000000-0xffbfffff: Memory-mapped devices
+ * 
+ * 0xffc00000: Page tables (see mem.c for how this works)
+ * 
+ * 0xfffff000: Page directory
+ */
+#define U_MEM_START 0x00100000
+#define U_MEM_END 0xbfffffff
+#define K_MEM_START 0xc0000000
+#define K_MEM_HEAP_START 0xd0000000
+#define K_MEM_HEAP_END 0xefffffff
+#define K_MEM_DEV_START 0xf0000000
+
 enum page_flags {
     PG_PRES = 1,
     PG_RW = 2,

--- a/kernel/arch/i686/include/x86/mem.h
+++ b/kernel/arch/i686/include/x86/mem.h
@@ -4,6 +4,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define PAGE_SIZE 4096
+#define HUGE_PAGE_SIZE 4194304
+
 /*
  * Memory map
  *
@@ -62,12 +65,19 @@ enum page_flags {
 void mem_set_bounds(uint32_t lower, uint32_t upper);
 void mem_set_used(uint32_t phys, uint32_t min_size);
 void mem_init(void);
+
+/*
+ * Maps a physical page starting at `phys` at the NEXT FREE virtual page,
+ * searching from `virt_min`.
+ */
 void *mem_map_page(uint32_t virt_min, uint32_t phys, enum page_flags flags);
 
 /*
- * Allocates `n` physical pages and maps them in contiguous virtual memory.
+ * Allocates and maps `n` physical pages starting at `virt`. Returns a pointer
+ * to `virt` if successful, or NULL if memory is already taken, or the memory
+ * region would reach beyond `virt_end_max`, or `virt` isn't page aligned.
  */
-void *mem_alloc_pages(uint32_t virt_min, uint32_t virt_end_max, size_t n,
+void *mem_alloc(uint32_t virt, uint32_t virt_end_max, size_t n,
         enum page_flags flags);
 
 #endif

--- a/kernel/arch/i686/include/x86/mem.h
+++ b/kernel/arch/i686/include/x86/mem.h
@@ -1,10 +1,3 @@
-/*
- * file: mem.h
- * description: Kernel memory management functionality. This is very
- *  architecture specific and its implementation is not portable at all at this
- *  point.
- */
-
 #ifndef MEM_H
 #define MEM_H
 
@@ -30,6 +23,8 @@ enum page_flags {
     PAGE_DIRECTORY_FLAGS = PG_PRES | PG_RW | PG_US,
 };
 
+void mem_set_bounds(uint32_t lower, uint32_t upper);
+void mem_set_used(uint32_t phys, uint32_t min_size);
 void mem_init(void);
 void *mem_map_page(uint32_t virt_min, uint32_t phys, enum page_flags flags);
 

--- a/kernel/arch/i686/include/x86/mem.h
+++ b/kernel/arch/i686/include/x86/mem.h
@@ -1,6 +1,7 @@
 #ifndef MEM_H
 #define MEM_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 /*
@@ -62,5 +63,11 @@ void mem_set_bounds(uint32_t lower, uint32_t upper);
 void mem_set_used(uint32_t phys, uint32_t min_size);
 void mem_init(void);
 void *mem_map_page(uint32_t virt_min, uint32_t phys, enum page_flags flags);
+
+/*
+ * Allocates `n` physical pages and maps them in contiguous virtual memory.
+ */
+void *mem_alloc_pages(uint32_t virt_min, uint32_t virt_end_max, size_t n,
+        enum page_flags flags);
 
 #endif

--- a/kernel/arch/i686/mem.c
+++ b/kernel/arch/i686/mem.c
@@ -30,8 +30,9 @@ extern char __kernel_virtual_offset, __kernel_start, __kernel_end;
 static uint32_t lower_bnd = PROT_PHYS_START, upper_bnd = PROT_PHYS_END;
 
 /* By mapping the last PDE to the page directory itself, we can access all
- * paging structures (in the current address space) starting at 0xffc00000.
- * (see boot.s for further explanation) */
+ * paging structures (in the current address space) starting at 0xffc00000,
+ * through the CPU interpreting the page directory as a page table and
+ * therefore the page tables it points to as its pages. */
 static uint32_t *page_directory = (uint32_t *)0xfffff000;
 
 static uint32_t *page_tables = (uint32_t *)0xffc00000;

--- a/kernel/arch/i686/mem.c
+++ b/kernel/arch/i686/mem.c
@@ -12,9 +12,6 @@
 #include <string.h>
 #include <stdio.h>
 
-#define PAGE_SIZE 4096
-#define HUGE_PAGE_SIZE 4194304
-
 /* The portion of physical memory that is guaranteed to be usable */
 #define PROT_PHYS_START 0x00100000
 #define PROT_PHYS_END 0x00f00000
@@ -125,45 +122,35 @@ void *mem_map_page(uint32_t virt_min, uint32_t phys, enum page_flags flags)
     return NULL;
 }
 
-void *mem_alloc_pages(uint32_t virt_min, uint32_t virt_end_max, size_t n,
+void *mem_alloc(uint32_t virt, uint32_t virt_end_max, size_t n,
         enum page_flags flags)
 {
     /* TODO: DRY this with `mem_map_page()` */
 
-    for (uint32_t virt = virt_min; virt < virt_end_max; virt += PAGE_SIZE) {
-        /* TODO: Optimize checks if page used? */
-        for (uint32_t single = virt; single < virt + n; single += PAGE_SIZE) {
-            if (single > virt_end_max)
-                return NULL;
-            
-            if ((page_directory[single / HUGE_PAGE_SIZE] & PG_PRES) == 0)
-                continue;
-            
-            if ((page_tables[single / PAGE_SIZE] & PG_PRES)) {
-                /* Continue after the used page. */
-                virt = single;
-                goto next;
-            }
-        }
-
-        /* No used page within reach - we've found space! */
-        for (uint32_t single = virt; single < virt + n; single += PAGE_SIZE) {
-            int pdi = single / HUGE_PAGE_SIZE;
-            if ((page_directory[pdi] & PG_PRES) == 0) {
-                page_directory[pdi] = alloc_phys() | PAGE_DIRECTORY_FLAGS;
-                memset(&page_tables[pdi * PAGE_TABLE_SIZE], 0, PAGE_SIZE);
-            }
-
-            int pti = single / PAGE_SIZE;
-            if ((page_tables[pti] & PG_PRES) == 0) {
-                page_tables[pti] = alloc_phys() | flags;
-            }
-        }
-        return (void *)virt;
-
-    next:
-        ;
+    /* TODO: Optimize checks if page used? */
+    for (uint32_t single = virt; single < virt + n; single += PAGE_SIZE) {
+        if (single > virt_end_max)
+            return NULL;
+        
+        if ((page_directory[single / HUGE_PAGE_SIZE] & PG_PRES) == 0)
+            continue;
+        
+        if ((page_tables[single / PAGE_SIZE] & PG_PRES))
+            return NULL;
     }
 
-    return NULL;
+    /* No used page within reach - we've found space! */
+    for (uint32_t single = virt; single < virt + n; single += PAGE_SIZE) {
+        int pdi = single / HUGE_PAGE_SIZE;
+        if ((page_directory[pdi] & PG_PRES) == 0) {
+            page_directory[pdi] = alloc_phys() | PAGE_DIRECTORY_FLAGS;
+            memset(&page_tables[pdi * PAGE_TABLE_SIZE], 0, PAGE_SIZE);
+        }
+
+        int pti = single / PAGE_SIZE;
+        if ((page_tables[pti] & PG_PRES) == 0) {
+            page_tables[pti] = alloc_phys() | flags;
+        }
+    }
+    return (void *)virt;
 }

--- a/kernel/arch/i686/mem.c
+++ b/kernel/arch/i686/mem.c
@@ -164,4 +164,6 @@ void *mem_alloc_pages(uint32_t virt_min, uint32_t virt_end_max, size_t n,
     next:
         ;
     }
+
+    return NULL;
 }

--- a/kernel/fs/tmpfs.c
+++ b/kernel/fs/tmpfs.c
@@ -162,7 +162,7 @@ int tmpfs_write(struct inode *ifile, off_t pos, const char *buf, size_t n)
     if (pos + n >= ifile->size)
         n = ifile->size - pos;
     
-    memcpy(f->buf, buf, n);
+    memcpy(&f->buf[pos], buf, n);
     return n;
 }
 
@@ -176,7 +176,7 @@ int tmpfs_read(struct inode *ifile, off_t pos, char *buf, size_t n)
     if (pos + n >= ifile->size)
         n = ifile->size - pos;
     
-    memcpy(buf, f->buf, n);
+    memcpy(buf, &f->buf[pos], n);
     return n;
 }
 

--- a/kernel/fs/tmpfs.c
+++ b/kernel/fs/tmpfs.c
@@ -1,0 +1,191 @@
+#include <stddef.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <fs/fs_dentry.h>
+#include <fs/fs_driver.h>
+#include <fs/fs_inode.h>
+#include <fs/fs_types.h>
+
+extern struct fs_driver tmpfs_driver;
+
+struct tmpfs_dentry {
+    struct dentry base;
+    struct tmpfs_dentry *next;
+};
+
+struct tmpfs_idir {
+    struct inode base;
+    struct tmpfs_dentry *first;
+};
+
+struct tmpfs_ifile {
+    struct inode base;
+    char buf[1024];
+};
+
+static void add_to_dir(struct tmpfs_idir *dir, const char *name,
+        struct inode *ino)
+{
+    char *name_buf = malloc(strlen(name));
+    strcpy(name_buf, name);
+
+    struct tmpfs_dentry *de = malloc(sizeof(struct tmpfs_dentry));
+
+    de->base.name = name_buf;
+    de->base.ino = ino;
+
+    de->next = NULL;
+
+    ino->nlink++;
+
+    if (dir->first == NULL){
+        dir->first = de;
+    } else {
+        struct tmpfs_dentry *last;
+        for (last = dir->first; last->next != NULL; last = last->next)
+            ;
+        last->next = de;
+    }
+}
+
+struct fs_instance *tmpfs_mount(struct file *file, int flags, void *args)
+{
+    struct fs_instance *fs = malloc(sizeof(struct fs_instance));
+
+    fs->driver = &tmpfs_driver;
+
+    struct tmpfs_idir *root = malloc(sizeof(struct tmpfs_idir));
+
+    root->base.nlink = 0;
+    root->base.fs_on = fs;
+    root->base.mode = flags & I_PERMS;
+    root->base.uid = 0;
+    root->base.gid = 0;
+    root->base.firstblk = 0;
+    root->base.size = 0;
+
+    root->first = NULL;
+    fs->root = &root->base;
+
+    return fs;
+}
+
+void tmpfs_destroy(struct fs_instance *fs)
+{
+    free(fs->root);
+    free(fs);
+}
+
+int tmpfs_create(struct inode *idir, const char *name, mode_t mode)
+{
+    struct tmpfs_ifile *f;
+    struct tmpfs_idir *d;
+
+    switch (mode & IT_TYPE) {
+    case IT_REG:
+        f = malloc(sizeof(struct tmpfs_ifile));
+
+        f->base.nlink = 0;
+        f->base.fs_on = idir->fs_on;
+        f->base.mode = mode;
+        f->base.uid = 0;
+        f->base.gid = 0;
+        f->base.firstblk = 0;
+        f->base.size = 1024;
+
+        memset(f->buf, 0, 1024);
+
+        add_to_dir((struct tmpfs_idir *)idir, name, &f->base);
+
+        return 0;
+    
+    case IT_DIR:
+        d = malloc(sizeof(struct tmpfs_idir));
+
+        d->base.nlink = 0;
+        d->base.fs_on = idir->fs_on;
+        d->base.mode = mode;
+        d->base.uid = 0;
+        d->base.gid = 0;
+        d->base.firstblk = 0;
+        d->base.size = 0;
+
+        d->first = NULL;
+
+        add_to_dir(d, ".", &d->base);
+        add_to_dir(d, "..", idir);
+        add_to_dir((struct tmpfs_idir *)idir, name, &d->base);
+
+        return 0;
+
+    default:
+        return -1;
+    }
+}
+
+struct dentry *tmpfs_lookup(struct inode *idir, const char *name)
+{
+    struct tmpfs_dentry *de;
+    
+    for (de = ((struct tmpfs_idir *)idir)->first; de != NULL; de = de->next) {
+        if (strcmp(de->base.name, name) == 0)
+            return &de->base;
+    }
+
+    return NULL;
+}
+
+int tmpfs_readdir(struct inode *idir, char **names, size_t n)
+{
+    size_t count = 0;
+
+    struct tmpfs_dentry *de;
+
+    for (de = ((struct tmpfs_idir *)idir)->first; de != NULL; de = de->next) {
+        if (count >= n)
+            break;
+        
+        *(names++) = (char *)de->base.name;
+        count++;
+    }
+    return count;
+}
+
+int tmpfs_write(struct inode *ifile, off_t pos, const char *buf, size_t n)
+{
+    if ((ifile->mode & IT_TYPE) != IT_REG)
+        return -1;
+    
+    struct tmpfs_ifile *f = (struct tmpfs_ifile *)ifile;
+
+    if (pos + n >= ifile->size)
+        n = ifile->size - pos;
+    
+    memcpy(f->buf, buf, n);
+    return n;
+}
+
+int tmpfs_read(struct inode *ifile, off_t pos, char *buf, size_t n)
+{
+    if ((ifile->mode & IT_TYPE) != IT_REG)
+        return -1;
+    
+    struct tmpfs_ifile *f = (struct tmpfs_ifile *)ifile;
+
+    if (pos + n >= ifile->size)
+        n = ifile->size - pos;
+    
+    memcpy(buf, f->buf, n);
+    return n;
+}
+
+struct fs_driver tmpfs_driver = {
+    .mount = tmpfs_mount,
+    .destroy = tmpfs_destroy,
+    .create = tmpfs_create,
+    .lookup = tmpfs_lookup,
+    .readdir = tmpfs_readdir,
+    .write = tmpfs_write,
+    .read = tmpfs_read,
+};

--- a/kernel/include/fs/fs_dentry.h
+++ b/kernel/include/fs/fs_dentry.h
@@ -1,0 +1,11 @@
+#ifndef FS_DENTRY_H
+#define FS_DENTRY_H
+
+struct inode;
+
+struct dentry {
+    const char *name;
+    struct inode *ino;
+};
+
+#endif

--- a/kernel/include/fs/fs_driver.h
+++ b/kernel/include/fs/fs_driver.h
@@ -1,0 +1,29 @@
+#ifndef FS_DRIVER
+#define FS_DRIVER
+
+#include <stddef.h>
+
+#include <fs/fs_types.h>
+
+struct dentry;
+struct file;
+struct inode;
+
+struct fs_instance;
+
+struct fs_driver {
+    struct fs_instance *(*mount)(struct file *, int, void *);
+    void (*destroy)(struct fs_instance *);
+
+    int (*create)(struct inode *, const char *, mode_t);
+    struct dentry *(*lookup)(struct inode *, const char *);
+    int (*readdir)(struct inode *, char **, size_t);
+    int (*write)(struct inode *, off_t, const char *, size_t);
+    int (*read)(struct inode *, off_t, char *, size_t);
+};
+
+struct fs_instance {
+    struct inode *root;
+};
+
+#endif

--- a/kernel/include/fs/fs_driver.h
+++ b/kernel/include/fs/fs_driver.h
@@ -23,6 +23,7 @@ struct fs_driver {
 };
 
 struct fs_instance {
+    struct fs_driver *driver;
     struct inode *root;
 };
 

--- a/kernel/include/fs/fs_inode.h
+++ b/kernel/include/fs/fs_inode.h
@@ -1,0 +1,22 @@
+#ifndef FS_INODE_H
+#define FS_INODE_H
+
+#include <fs/fs_types.h>
+
+struct fs_instance;
+
+struct inode {
+    nlink_t nlink;
+
+    mode_t mode;
+
+    uid_t uid;
+    gid_t gid;
+
+    off_t firstblk;
+    off_t size;
+
+    struct fs_instance *fs_on;
+};
+
+#endif

--- a/kernel/include/fs/fs_types.h
+++ b/kernel/include/fs/fs_types.h
@@ -18,6 +18,8 @@ enum i_perms {
     I_WOTH = 0200,
     I_ROTH = 0400,
     I_RWXO = 0700,
+
+    I_PERMS = 0777,
 };
 
 enum i_type {

--- a/kernel/include/fs/fs_types.h
+++ b/kernel/include/fs/fs_types.h
@@ -1,0 +1,46 @@
+#ifndef FS_TYPES_H
+#define FS_TYPES_H
+
+#include <stdint.h>
+
+enum i_perms {
+    I_XUSR = 0001,
+    I_WUSR = 0002,
+    I_RUSR = 0004,
+    I_RWXU = 0007,
+
+    I_XGRP = 0010,
+    I_WGRP = 0020,
+    I_RGRP = 0040,
+    I_RWXG = 0070,
+
+    I_XOTH = 0100,
+    I_WOTH = 0200,
+    I_ROTH = 0400,
+    I_RWXO = 0700,
+};
+
+enum i_type {
+    IT_UNK,
+
+    IT_REG = 01000,
+    IT_DIR = 02000,
+    IT_BLK = 03000,
+    IT_CHR = 04000,
+    IT_FIFO = 05000,
+    IT_LNK = 06000,
+    IT_SOCK = 07000,
+
+    IT_TYPE = 07000,
+};
+
+typedef uint16_t nlink_t;
+
+typedef uint16_t mode_t;
+
+typedef uint32_t uid_t;
+typedef uint32_t gid_t;
+
+typedef uint64_t off_t;
+
+#endif

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,7 +1,7 @@
 INCLUDES=-Iinclude
 CCFLAGS+=$(INCLUDES) -ffreestanding
 
-LIBK_INCLUDES=-I../kernel/include
+LIBK_INCLUDES=-I../kernel/include -I../kernel/arch/$(ARCH)/include
 LIBK_CCFLAGS=$(LIBK_INCLUDES) -D__is_kernel
 
 LIBS=-nostdlib -lgcc

--- a/libc/arch/i686/malloc.c
+++ b/libc/arch/i686/malloc.c
@@ -1,0 +1,27 @@
+#include <stdlib.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __is_kernel
+
+#include <stdio.h>
+
+void *malloc(size_t size)
+{
+    static uint32_t addr = __BIGGEST_ALIGNMENT__;
+    
+    void *ret = (void *)addr;
+
+    addr += size;
+    if (addr % __BIGGEST_ALIGNMENT__ != 0)
+        addr += __BIGGEST_ALIGNMENT__ - addr % __BIGGEST_ALIGNMENT__;
+    
+    return ret;
+}
+
+void free(void *ptr)
+{
+}
+
+#endif

--- a/libc/arch/i686/malloc.c
+++ b/libc/arch/i686/malloc.c
@@ -1,27 +1,127 @@
 #include <stdlib.h>
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #ifdef __is_kernel
 
-#include <stdio.h>
+#include <x86/mem.h>
+
+enum alloc_status {
+    USED = (1 << 0),
+    END_OF_MEMORY = (1 << 1),
+};
+
+/* TODO: Guarantee max alignment on changes to structure! */
+struct alloc_header {
+    uint8_t status;
+    size_t size;
+    
+    struct alloc_header *prev_header;
+
+    uint32_t _pad;
+};
+
+static struct alloc_header *first_hdr;
+
+static struct alloc_header *find_next_hdr(struct alloc_header *hdr)
+{
+    return (void *)hdr + sizeof(struct alloc_header) + hdr->size;
+}
 
 void *malloc(size_t size)
 {
-    static uint32_t addr = __BIGGEST_ALIGNMENT__;
-    
-    void *ret = (void *)addr;
+    /* Guarantee max alignment: round up size to the nearest multiple of 16 */
+    size = (size + 15) & ~15;
 
-    addr += size;
-    if (addr % __BIGGEST_ALIGNMENT__ != 0)
-        addr += __BIGGEST_ALIGNMENT__ - addr % __BIGGEST_ALIGNMENT__;
+    /* Traverse headers until we have found a large enough space or reached the
+     * end of allocated heap. */
+    struct alloc_header *hdr = first_hdr;
+    while (hdr && ((hdr->status & USED) || (hdr->size < size)) &&
+            !(hdr->status & END_OF_MEMORY))
+        hdr = find_next_hdr(hdr);
     
-    return ret;
+    /* Allocate more heap if necessary. */
+    if (!hdr || (((hdr->status & USED) || (hdr->size < size)) &&
+            (hdr->status & END_OF_MEMORY))) {
+        size_t n = (size + sizeof(struct alloc_header)) / PAGE_SIZE + 1;
+
+        struct alloc_header *new_hdr = mem_alloc(
+                hdr ? (uint32_t)find_next_hdr(hdr) : K_MEM_HEAP_START,
+                K_MEM_HEAP_END,
+                n,
+                DEFAULT_PAGE_FLAGS);
+        
+        new_hdr->status = END_OF_MEMORY;
+        new_hdr->size = n * PAGE_SIZE - sizeof(struct alloc_header);
+        new_hdr->prev_header = hdr;
+
+        if (hdr)
+            hdr->status &= ~END_OF_MEMORY;
+        else
+            first_hdr = new_hdr;
+
+        hdr = new_hdr;
+    }
+
+    hdr->status |= USED;
+
+    /* If we have much more space than required for the allocation, split the
+     * block in two. */
+    if (hdr->size >= size + 2 * sizeof(struct alloc_header)) {
+        size_t remaining = hdr->size - (size + 2 * sizeof(struct alloc_header));
+
+        hdr->size = size;
+
+        struct alloc_header *next_hdr = find_next_hdr(hdr);
+        next_hdr->status = 0;
+        next_hdr->prev_header = hdr;
+        next_hdr->size = remaining;
+
+        if (hdr->status & END_OF_MEMORY) {
+            hdr->status &= ~END_OF_MEMORY;
+            next_hdr->status |= END_OF_MEMORY;
+        } else {
+            struct alloc_header *next_next = find_next_hdr(next_hdr);
+            next_next->prev_header = next_hdr;
+        }
+    }
+    
+    return &hdr[1];
 }
 
 void free(void *ptr)
 {
+    struct alloc_header *hdr = ((struct alloc_header *)ptr) - 1;
+
+    /* Merge with prev block if free (required to make one large allocation
+     * possible in space previously fragmented by multiple smaller ones). */
+    struct alloc_header *prev_hdr = hdr->prev_header;
+    if (prev_hdr != NULL && !(prev_hdr->status & USED)) {
+        prev_hdr->size += hdr->size;
+        prev_hdr->status |= hdr->status & END_OF_MEMORY;
+        hdr = prev_hdr;
+    }
+    
+    /* Merge with next block if free. */
+    if (!(hdr->status == END_OF_MEMORY)) {
+        struct alloc_header *next_hdr = (void *)hdr +
+                sizeof(struct alloc_header) + hdr->size;
+        
+        if (!(next_hdr->status & USED)) {
+            hdr->size += next_hdr->size;
+            hdr->status |= next_hdr->status & END_OF_MEMORY;
+
+            if (!(next_hdr->status & END_OF_MEMORY)) {
+                struct alloc_header *next_next = find_next_hdr(next_hdr);
+                next_next->prev_header = hdr;
+            }
+        }
+    }
+
+    /* If we couldn't merge it, mark as free for later allocations/merges. */
+    hdr->status &= ~USED;
 }
 
 #endif

--- a/libc/arch/i686/malloc.c
+++ b/libc/arch/i686/malloc.c
@@ -6,6 +6,8 @@
 
 #ifdef __is_kernel
 
+#include <stdio.h>
+
 #include <x86/mem.h>
 
 enum alloc_status {
@@ -70,7 +72,7 @@ void *malloc(size_t size)
     /* If we have much more space than required for the allocation, split the
      * block in two. */
     if (hdr->size >= size + 2 * sizeof(struct alloc_header)) {
-        size_t remaining = hdr->size - (size + 2 * sizeof(struct alloc_header));
+        size_t remaining = hdr->size - (size + sizeof(struct alloc_header));
 
         hdr->size = size;
 
@@ -87,7 +89,7 @@ void *malloc(size_t size)
             next_next->prev_header = next_hdr;
         }
     }
-    
+
     return &hdr[1];
 }
 

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -1,0 +1,14 @@
+#ifndef __STDLIB_H
+#define __STDLIB_H
+
+/* NULL, size_t */
+#include <stddef.h>
+
+#ifdef __is_kernel
+
+void *malloc(size_t size);
+void free(void *ptr);
+
+#endif
+
+#endif


### PR DESCRIPTION
Actually mostly memory allocation, but really useful and had to be done before even attempting physical file system shenanigans.

- Define basic types for the VFS
- Start defining the filesystem driver interface
- Implement `kmalloc` (terribly) for test purposes
- Add in-memory (tmp) filesystem
- fix: Make `hlinit()` obey calling convention
- Parse GRUB memory maps
- Add kernel + user space virtual memory map
- Implement multiple page allocator + mapper
- fix: Shut up code analysis
- rewrite: `mem_alloc_pages(min)` -> `mem_alloc_pages` *exact*
- Implement `malloc()` properly
- Dummy/test VFS and `malloc()` with tmpfs
- fix: Don't ignore offset into tmpfs buffer
- fix: `malloc()` "miscounting" sizes
- fix: Use GRUB's physical memory map correctly
- fix: count pages instead of bytes
- Test tmpfs support for larger files (> 1 block)
